### PR TITLE
Improve build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "postinstall": "npm run build && npm run build:min",
+    "prebuild": "rimraf dist",
     "build": "rollup --config",
     "build:min": "rollup --config --sourcemap --environment MINIFY",
     "test": "xo"
@@ -42,6 +43,7 @@
     "eslint-plugin-react": "^6.10.3",
     "glamor": "^2.20.24",
     "react": "^15.4.2",
+    "rimraf": "^2.6.1",
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "url": "https://github.com/paulmolluzzo/glamorous-jsxstyle.git"
   },
   "scripts": {
-    "postinstall": "npm run build",
+    "postinstall": "npm run build && npm run build:min",
     "build": "rollup --config",
+    "build:min": "rollup --config --sourcemap --environment MINIFY",
     "test": "xo"
   },
   "keywords": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,10 +7,12 @@ const minify = process.env.MINIFY
 
 export default {
   entry: 'index.js',
-  targets: [
-    {dest: 'dist/glamorous-jsxstyle.umd.js', format: 'umd'},
-    {dest: 'dist/glamorous-jsxstyle.es.js', format: 'es'},
-    {dest: 'dist/glamorous-jsxstyle.cjs.js', format: 'cjs'}
+  targets: minify ?
+    [{dest: 'dist/glamorous-jsxstyle.umd.min.js', format: 'umd'}] :
+  [
+        {dest: 'dist/glamorous-jsxstyle.umd.js', format: 'umd'},
+        {dest: 'dist/glamorous-jsxstyle.es.js', format: 'es'},
+        {dest: 'dist/glamorous-jsxstyle.cjs.js', format: 'cjs'}
   ],
   exports: 'default',
   moduleName: 'glamorous-jsxstyle',
@@ -27,7 +29,7 @@ export default {
     rollupBabel({
       exclude: 'node_modules/**',
       babelrc: false,
-      presets: ['stage-2', 'react']
+      presets: [['env', {modules: false}], 'stage-2', 'react']
     }),
     minify ? uglify() : null
   ].filter(Boolean)


### PR DESCRIPTION
✅   Adds `build:min` script to generate a minified version of the umd module.
✅  Appends the new `build:min` script to the `postinstall` script
✅  Removes `dist` directory before rebuilding modules
