### PR TITLE
Add more display properties for tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 # jsxstyle Components
 
-This package exports jsxstyle components generated with [`glamorous`](https://github.com/paypal/glamorous/)
+This package exports the components from [`jsxstyle`](https://github.com/smyte/jsxstyle) using [`glamorous`](https://github.com/paypal/glamorous/).
+
+From [`jsxstyle`](https://github.com/smyte/jsxstyle):
+
+> `jsxstyle` includes components corresponding to every potential value of the CSS `display` property.
+
+This package follows that same purpose and generates and exposes components named after `display` properties. The list of components generated are:
+
+* `View`
+* `Block`
+* `InlineBlock`
+* `InlineListItem`
+* `Flex`
+* `Row`
+* `Column`
+* `Table`
+* `InlineTable`
+* `TableRowGroup`
+* `TableHeaderGroup`
+* `TableFooterGroup`
+* `TableRow`
+* `TableCell`
+* `TableColumnGroup`
+* `TableColumn`
+* `TableCaption`
 
 # Install
 

--- a/index.js
+++ b/index.js
@@ -1,46 +1,26 @@
 import glamorous from 'glamorous'
 
 // A <div>
-const View = glamorous.div()
+export const View = glamorous.div()
 
 // Blocks
-const Block = glamorous.div({display: 'block'})
-const InlineBlock = glamorous.div({display: 'inline-block'})
-const InlineListItem = glamorous.div({display: 'inline-list-item'})
+export const Block = glamorous.div({display: 'block'})
+export const InlineBlock = glamorous.div({display: 'inline-block'})
+export const InlineListItem = glamorous.div({display: 'inline-list-item'})
 
 // Flex
-const Flex = glamorous.div({display: 'flex'})
-const Row = glamorous.div({display: 'flex', flexDirection: 'row'})
-const Column = glamorous.div({display: 'flex', flexDirection: 'column'})
+export const Flex = glamorous.div({display: 'flex'})
+export const Row = glamorous.div({display: 'flex', flexDirection: 'row'})
+export const Column = glamorous.div({display: 'flex', flexDirection: 'column'})
 
 // Tables
-const Table = glamorous.div({display: 'table'})
-const InlineTable = glamorous.div({display: 'inline-table'}) // Behaves like a <table> HTML element, but as an inline box
-const TableRowGroup = glamorous.div({display: 'table-row-group'}) // These elements behave like <tbody> HTML elements
-const TableHeaderGroup = glamorous.div({display: 'table-header-group'}) // These elements behave like <thead> HTML elements.
-const TableFooterGroup = glamorous.div({display: 'table-footer-group'}) // These elements behave like <tfoot> HTML elements.
-const TableRow = glamorous.div({display: 'table-row'}) // These elements behave like <tr> HTML elements.
-const TableCell = glamorous.div({display: 'table-cell'}) // These elements behave like <td> HTML elements.
-const TableColumnGroup = glamorous.div({display: 'table-column-group'}) // These elements behave like <colgroup> HTML elements.
-const TableColumn = glamorous.div({display: 'table-column'}) // These elements behave like <col> HTML elements.
-const TableCaption = glamorous.div({display: 'table-caption'}) // These elements behave like <caption> HTML elements.
-
-export default {
-  View,
-  Block,
-  InlineBlock,
-  InlineListItem,
-  Flex,
-  Row,
-  Column,
-  Table,
-  InlineTable,
-  TableRowGroup,
-  TableHeaderGroup,
-  TableFooterGroup,
-  TableRow,
-  TableCell,
-  TableColumnGroup,
-  TableColumn,
-  TableCaption
-}
+export const Table = glamorous.div({display: 'table'})
+export const InlineTable = glamorous.div({display: 'inline-table'}) // Behaves like a <table> HTML element, but as an inline box
+export const TableRowGroup = glamorous.div({display: 'table-row-group'}) // These elements behave like <tbody> HTML elements
+export const TableHeaderGroup = glamorous.div({display: 'table-header-group'}) // These elements behave like <thead> HTML elements.
+export const TableFooterGroup = glamorous.div({display: 'table-footer-group'}) // These elements behave like <tfoot> HTML elements.
+export const TableRow = glamorous.div({display: 'table-row'}) // These elements behave like <tr> HTML elements.
+export const TableCell = glamorous.div({display: 'table-cell'}) // These elements behave like <td> HTML elements.
+export const TableColumnGroup = glamorous.div({display: 'table-column-group'}) // These elements behave like <colgroup> HTML elements.
+export const TableColumn = glamorous.div({display: 'table-column'}) // These elements behave like <col> HTML elements.
+export const TableCaption = glamorous.div({display: 'table-caption'}) // These elements behave like <caption> HTML elements.

--- a/index.js
+++ b/index.js
@@ -1,17 +1,46 @@
 import glamorous from 'glamorous'
 
+// A <div>
 const View = glamorous.div()
+
+// Blocks
 const Block = glamorous.div({display: 'block'})
 const InlineBlock = glamorous.div({display: 'inline-block'})
+const InlineListItem = glamorous.div({display: 'inline-list-item'})
+
+// Flex
 const Flex = glamorous.div({display: 'flex'})
 const Row = glamorous.div({display: 'flex', flexDirection: 'row'})
 const Column = glamorous.div({display: 'flex', flexDirection: 'column'})
+
+// Tables
+const Table = glamorous.div({display: 'table'})
+const InlineTable = glamorous.div({display: 'inline-table'}) // Behaves like a <table> HTML element, but as an inline box
+const TableRowGroup = glamorous.div({display: 'table-row-group'}) // These elements behave like <tbody> HTML elements
+const TableHeaderGroup = glamorous.div({display: 'table-header-group'}) // These elements behave like <thead> HTML elements.
+const TableFooterGroup = glamorous.div({display: 'table-footer-group'}) // These elements behave like <tfoot> HTML elements.
+const TableRow = glamorous.div({display: 'table-row'}) // These elements behave like <tr> HTML elements.
+const TableCell = glamorous.div({display: 'table-cell'}) // These elements behave like <td> HTML elements.
+const TableColumnGroup = glamorous.div({display: 'table-column-group'}) // These elements behave like <colgroup> HTML elements.
+const TableColumn = glamorous.div({display: 'table-column'}) // These elements behave like <col> HTML elements.
+const TableCaption = glamorous.div({display: 'table-caption'}) // These elements behave like <caption> HTML elements.
 
 export default {
   View,
   Block,
   InlineBlock,
+  InlineListItem,
   Flex,
   Row,
-  Column
+  Column,
+  Table,
+  InlineTable,
+  TableRowGroup,
+  TableHeaderGroup,
+  TableFooterGroup,
+  TableRow,
+  TableCell,
+  TableColumnGroup,
+  TableColumn,
+  TableCaption
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ export default {
         {dest: 'dist/glamorous-jsxstyle.es.js', format: 'es'},
         {dest: 'dist/glamorous-jsxstyle.cjs.js', format: 'cjs'}
   ],
-  exports: 'default',
+  exports: 'auto',
   moduleName: 'glamorous-jsxstyle',
   format: 'umd',
   external: ['react', 'glamor', 'glamorous'],


### PR DESCRIPTION
Adds more components being generated to make the list become:

* `View`
* `Block`
* `InlineBlock`
* `InlineListItem`
* `Flex`
* `Row`
* `Column`
* `Table`
* `InlineTable`
* `TableRowGroup`
* `TableHeaderGroup`
* `TableFooterGroup`
* `TableRow`
* `TableCell`
* `TableColumnGroup`
* `TableColumn`
* `TableCaption`