### PR TITLE
Fix broken install process by moving rollup into build; list dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "type": "git",
     "url": "https://github.com/paulmolluzzo/glamorous-jsxstyle.git"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "postinstall": "npm run build && npm run build:min",
     "prebuild": "rimraf dist",
-    "build": "rollup --config",
+    "build": "rollup --config && build:min",
     "build:min": "rollup --config --sourcemap --environment MINIFY",
     "test": "xo"
   },


### PR DESCRIPTION
This is a critical fix, and I'm guessing it broke stuff for people. 😭 

1) The `rollup` processes were moved out of `postinstall` - the dependencies weren't ready yet. :man_facepalming: 
2) I added the `files` to the package.json so that only the rolled up `dist` is in your `node_modules`, hopefully avoiding any breaking issues. :crossed_fingers: 